### PR TITLE
Playlist length fix for single sequence

### DIFF
--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -646,9 +646,14 @@ with open(fifo_path, 'r') as fifo:
         logging.info('Processing MainPlaylist')
         playlist_name = line[8:]
         logging.debug('Playlist Name: {0}'.format(playlist_name))
-        response = urlopen('http://localhost/api/playlist/{0}'.format(quote(playlist_name)))
-        data = response.read()
-        playlist_length = len(json.loads(data)['mainPlaylist'])
+        playlist_length = 1
+        if '.' not in playlist_name: # Case where a sequence is directly run from the scheduler or status page, it ends in .fseq and . is not allowed in regular playlist names
+          try:
+            response = urlopen('http://localhost/api/playlist/{0}'.format(quote(playlist_name)))
+            data = response.read()
+            playlist_length = len(json.loads(data)['mainPlaylist'])
+          except Exception:
+            logging.exception("Playlist Length")
         logging.debug('Playlist Length: {0}'.format(playlist_length))
         if rdsValues['{C}'] != str(playlist_length):
           rdsValues['{C}'] = str(playlist_length)


### PR DESCRIPTION
Fixes #20 
When a single sequence is directly run from the scheduler or status page, FPP sets the playlist name as <sequence name>.fseq. Engine would use the api/playlist/<sequence name>.fseq to determine the playlist length, but it would return "". This caused a parsing error.

Solution was to check playlist name for a '.' since that isn't a valid character in a regular playlist.