### PR TITLE
Failing to restart with PWM enabled

### DIFF
--- a/Dynamic_RDS.php
+++ b/Dynamic_RDS.php
@@ -58,7 +58,7 @@ if (isset($pluginSettings['DynRDSQN8066PIHardwarePWM']) && $pluginSettings['DynR
  if (shell_exec("lsmod | grep 'snd_bcm2835.*1\>'")) {
   echo '<div class="callout callout-warning">On-board sound card appears active and will interfere with hardware PWM. Try a reboot first, next toggle the Enable PI Hardware PWM setting below and reboot. If issues persist check /boot/config.txt and comment out dtparam=audio=on</div>';
  }
- if (empty(shell_exec("lsmod | grep pwm"))) {
+ if (empty(shell_exec("lsmod | grep pwm")) || !file_exists('/sys/class/pwm/pwmchip0')) {
   echo '<div class="callout callout-warning">Hardware PWM has not been loaded. Try a reboot first, next toggle the Enable PI Hardware PWM setting below and reboot. If issues persist then check /boot/config.txt and add dtoverlay=pwm</div>';
  }
 }

--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -38,7 +38,7 @@ def cleanup():
       logging.debug('Stopped PWM')
       with open(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}/enable', 'w', encoding='UTF-8') as p:
         p.write('0\n')
-      logging.info(f'Disabled PWM{pwmToUse}')
+      logging.info('Disabled PWM%s', pwmToUse)
   except:
     pass
   logging.info('Exiting')

--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -17,6 +17,10 @@ from urllib.parse import quote
 from config import config, read_config_from_file
 from QN8066 import QN8066
 
+def logUnhandledException(eType, eValue, eTraceback):
+  logging.error("Unhandled exception", exc_info=(eType, eValue, eTraceback))
+sys.excepthook = logUnhandledException
+
 @atexit.register
 def cleanup():
   try:
@@ -26,12 +30,15 @@ def cleanup():
     pass
   try:
     if os.path.isdir('/sys/class/pwm/pwmchip0') and os.access('/sys/class/pwm/pwmchip0/export', os.W_OK):
-      with open('/sys/class/pwm/pwmchip0/pwm0/duty_cycle', 'w', encoding='UTF-8') as p:
+      pwmToUse = 0
+      if config['DynRDSAdvPIPWMPin'] in {'13,4' , '19,2'}:
+        pwmToUse = 1
+      with open(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}/duty_cycle', 'w', encoding='UTF-8') as p:
         p.write('0\n')
       logging.debug('Stopped PWM')
-      with open('/sys/class/pwm/pwmchip0/pwm0/enable', 'w', encoding='UTF-8') as p:
+      with open(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}/enable', 'w', encoding='UTF-8') as p:
         p.write('0\n')
-      logging.info('Disabled PWM')
+      logging.info(f'Disabled PWM{pwmToUse}')
   except:
     pass
   logging.info('Exiting')

--- a/QN8066.py
+++ b/QN8066.py
@@ -66,11 +66,11 @@ class QN8066(Transmitter):
       pwmToUse = 0
       if config['DynRDSAdvPIPWMPin'] in {'13,4' , '19,2'}:
         pwmToUse = 1
-      logging.debug(f'Setting up PWM{pwmToUse}')
+      logging.debug('Setting up PWM%s', pwmToUse)
 
       # Export PWM commands if needed
       if not os.path.isdir(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}'):
-        logging.debug(f'Exporting PWM{pwmToUse}')
+        logging.debug('Exporting PWM%s', pwmToUse)
         with open('/sys/class/pwm/pwmchip0/export', 'w', encoding='UTF-8') as p:
           p.write(f'{pwmToUse}\n')
 
@@ -82,7 +82,7 @@ class QN8066(Transmitter):
       with open(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}/duty_cycle', 'w', encoding='UTF-8') as p:
         p.write(f'{int(config["DynRDSQN8066AmpPower"]) * 61}\n')
 
-      logging.info(f'Enabling PWM{pwmToUse}')
+      logging.info('Enabling PWM%s', pwmToUse)
       with open(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}/enable', 'w', encoding='UTF-8') as p:
         p.write('1\n')
       self.activePWM = True

--- a/QN8066.py
+++ b/QN8066.py
@@ -63,13 +63,14 @@ class QN8066(Transmitter):
     # TODO: Check to see if PWM is enabled and amp power > 0, otherwise skip this
     # Check that PWM configured in /boot/config.txt and can be written to
     if os.path.isdir('/sys/class/pwm/pwmchip0') and os.access('/sys/class/pwm/pwmchip0/export', os.W_OK):
-      logging.debug('Setting up PWM')
+      pwmToUse = 0
+      if config['DynRDSAdvPIPWMPin'] in {'13,4' , '19,2'}:
+        pwmToUse = 1
+      logging.debug(f'Setting up PWM{pwmToUse}')
+
       # Export PWM commands if needed
-      if not (os.path.isdir('/sys/class/pwm/pwmchip0/pwm0') or os.path.isdir('/sys/class/pwm/pwmchip0/pwm1')):
-        logging.debug('Exporting PWM')
-        pwmToUse = 0
-        if config['DynRDSAdvPIPWMPin'] in {'13,4' , '19,2'}:
-          pwmToUse = 1
+      if not os.path.isdir(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}'):
+        logging.debug(f'Exporting PWM{pwmToUse}')
         with open('/sys/class/pwm/pwmchip0/export', 'w', encoding='UTF-8') as p:
           p.write(f'{pwmToUse}\n')
 
@@ -81,7 +82,7 @@ class QN8066(Transmitter):
       with open(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}/duty_cycle', 'w', encoding='UTF-8') as p:
         p.write(f'{int(config["DynRDSQN8066AmpPower"]) * 61}\n')
 
-      logging.info('Enabling PWM')
+      logging.info(f'Enabling PWM{pwmToUse}')
       with open(f'/sys/class/pwm/pwmchip0/pwm{pwmToUse}/enable', 'w', encoding='UTF-8') as p:
         p.write('1\n')
       self.activePWM = True

--- a/callbacks.py
+++ b/callbacks.py
@@ -12,6 +12,10 @@ from sys import argv
 
 from config import config,read_config_from_file
 
+def logUnhandledException(eType, eValue, eTraceback):
+  logging.error("Unhandled exception", exc_info=(eType, eValue, eTraceback))
+sys.excepthook = logUnhandledException
+
 if len(argv) <= 1:
   print('Usage:')
   print('   --list     | Used by fppd at startup. Used to start up the Dynamic_RDS_Engine.py script')


### PR DESCRIPTION
Fixed the root cause by moving pwmToUse up in scope so it is valid for any PWM code. Clean up code handles PWM0 or PWM1 as needed. Improved PWM logging. Added an unhandled exception logging function.

Fixes issue #37 