### PR TITLE
MQTT support

### DIFF
--- a/Dynamic_RDS.php
+++ b/Dynamic_RDS.php
@@ -189,9 +189,17 @@ PrintSettingGroup("DynRDSPowerSettings", "", "", 1, "Dynamic_RDS", "DynRDSPiBoot
 PrintSettingGroup("DynRDSPluginActivation", "", "Set when the transmitter is active", 1, "Dynamic_RDS");
 
 if (!(is_file('/bin/mpc') || is_file('/usr/bin/mpc'))) {
-  echo '<h2>MPC / After Hours Music</h2><div class="callout callout-warning">MPC not detected. Functionality not available. Install After Hours Music Player Plugin to enabled.</div><br />';
+  echo '<h2>MPC / After Hours Music</h2><div class="callout callout-default">MPC not detected. Functionality not available. Install After Hours Music Player Plugin to enabled.</div><br />';
 } else {
-PrintSettingGroup("DynRDSmpc", "", "Pull RDS data from MPC / After Hours Music plugin when idle", 1, "Dynamic_RDS", "DynRDSFastUpdate");
+  PrintSettingGroup("DynRDSmpc", "", "Pull RDS data from MPC / After Hours Music plugin when idle", 1, "Dynamic_RDS", "DynRDSFastUpdate");
+}
+
+if ($settings['MQTTHost'] == '') {
+  echo '<h2>MQTT</h2><div class="callout callout-default">Requires that MQTT has been configured under <a href="settings.php#settings-mqtt">FPP Settings -&gt; MQTT</a></div><br />';
+} elseif (false) {
+
+} else {
+  PrintSettingGroup("DynRDSmqtt", "", "Will connect to <b>" . $settings['MQTTHost'] . ":" . $settings['MQTTPort'] . "</b>", 1, "Dynamic_RDS", "");
 }
 
 PrintSettingGroup("DynRDSLogLevel", "", "", 1, "Dynamic_RDS", "DynRDSFastUpdate");

--- a/Dynamic_RDS.php
+++ b/Dynamic_RDS.php
@@ -157,6 +157,17 @@ function DynRDSPiBootUpdate(key) {
   // Object.assign({},pluginSettings) converts to an object from an associative array. Very likely pluginSettings could be changed
   // to be an object instead of an array in FPP's code
 }
+
+function DynRDSScriptStream() {
+  var url = 'api/plugin/Dynamic_RDS/ScriptStream';
+  DisplayProgressDialog('DynRDSScriptStream', 'Install MQTT');
+  StreamURL(url, 'DynRDSScriptStreamText', 'ScriptStreamProgressDialogDone', 'ScriptStreamProgressDialogDone', 'POST');
+}
+
+function ScriptStreamProgressDialogDone() {
+    $('#DynRDSScriptStreamCloseButton').prop('disabled', false);
+    EnableModalDialogCloseButton('DynRDSScriptStream');
+}
 </script>
 
 <?
@@ -196,8 +207,8 @@ if (!(is_file('/bin/mpc') || is_file('/usr/bin/mpc'))) {
 
 if ($settings['MQTTHost'] == '') {
   echo '<h2>MQTT</h2><div class="callout callout-default">Requires that MQTT has been configured under <a href="settings.php#settings-mqtt">FPP Settings -&gt; MQTT</a></div><br />';
-} elseif (false) {
-
+} elseif (!(file_exists('/usr/lib/python3/dist-packages/paho') || file_exists('/usr/local/lib/python3.9/dist-packages/paho'))) {
+  echo '<h2>MQTT</h2><div class="callout callout-warning">python3-paho-mqtt is missing <button name="pahoInstall" onClick="DynRDSScriptStream(\'paho\');">Install python3-paho-mqtt</button></div>';
 } else {
   PrintSettingGroup("DynRDSmqtt", "", "Will connect to <b>" . $settings['MQTTHost'] . ":" . $settings['MQTTPort'] . "</b>", 1, "Dynamic_RDS", "");
 }

--- a/Dynamic_RDS.php
+++ b/Dynamic_RDS.php
@@ -193,7 +193,7 @@ PrintSettingGroup("DynRDSPowerSettings", "", "", 1, "Dynamic_RDS", "DynRDSPiBoot
 PrintSettingGroup("DynRDSPluginActivation", "", "Set when the transmitter is active", 1, "Dynamic_RDS");
 
 if (!(is_file('/bin/mpc') || is_file('/usr/bin/mpc'))) {
-  echo '<h2>MPC / After Hours Music</h2><div class="callout callout-default">MPC not detected. Functionality not available. Install After Hours Music Player Plugin to enabled.</div><br />';
+  echo '<h2>MPC / After Hours Music</h2><div class="callout callout-default">Install the After Hours Music Player Plugin to enabled. MPC not detected</div><br />';
 } else {
   PrintSettingGroup("DynRDSmpc", "", "Pull RDS data from MPC / After Hours Music plugin when idle", 1, "Dynamic_RDS", "DynRDSFastUpdate");
 }
@@ -201,7 +201,7 @@ if (!(is_file('/bin/mpc') || is_file('/usr/bin/mpc'))) {
 if ($settings['MQTTHost'] == '') {
   echo '<h2>MQTT</h2><div class="callout callout-default">Requires that MQTT has been configured under <a href="settings.php#settings-mqtt">FPP Settings -&gt; MQTT</a></div><br />';
 } elseif (!(file_exists('/usr/lib/python3/dist-packages/paho') || file_exists('/usr/local/lib/python3.9/dist-packages/paho'))) {
-  echo '<h2>MQTT</h2><div class="callout callout-warning">python3-paho-mqtt is needed to enable MQTT support <button name="pahoInstall" onClick="DynRDSScriptStream(\'python3-paho-mqtt\');">Install python3-paho-mqtt</button></div>';
+  echo '<h2>MQTT</h2><div class="callout callout-default">python3-paho-mqtt is needed to enable MQTT support <button name="pahoInstall" onClick="DynRDSScriptStream(\'python3-paho-mqtt\');">Install python3-paho-mqtt</button></div>';
 } else {
   PrintSettingGroup("DynRDSmqtt", "", "Broker Host is <b>" . $settings['MQTTHost'] . ":" . $settings['MQTTPort'] . "</b>", 1, "Dynamic_RDS", "");
 }

--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -257,7 +257,7 @@ with open(fifo_path, 'r', encoding='UTF-8') as fifo:
 
       elif line.startswith('MAINLIST'):
         logging.info('Processing MainPlaylist')
-        playlist_name = line[8:]
+        playlist_name = line[8:] # TODO: Need to keep track of last playlist name to reduce overhead?
         if playlist_name != '':
           logging.debug('Playlist Name: %s', playlist_name)
           playlist_length = 1
@@ -291,7 +291,7 @@ with open(fifo_path, 'r', encoding='UTF-8') as fifo:
         # TANL is always sent together with L being last item, so we only need to update the RDS Data once with the new values
         # TODO: This will likely change as more data is added, so a new way will have to be determined
         updateRDSData()
-        activePlaylist = True
+        #activePlaylist = True # TODO: Is this needed still?
         transmitter.status()
 
       # All of the rdsValues that are stored as is

--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -190,7 +190,7 @@ with open(fifo_path, 'r', encoding='UTF-8') as fifo:
       logging.debug('line %s', line)
       if line == 'EXIT':
         logging.info('Processing exit')
-        transmitter.shutdown()
+        transmitter.shutdown() # TODO: Can fail if transmitter wasn't set - Can fix with an if statement or look into using Transmitter base class initially
         mqtt.disconnect()
         sys.exit()
 

--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -217,7 +217,11 @@ with open(fifo_path, 'r', encoding='UTF-8') as fifo:
           continue
 
         if config['DynRDSmqttEnable'] == "1":
-          mqtt = pahoMQTT()
+           try:
+             mqtt = pahoMQTT()
+           except Exception:
+             logging.exception('Unable to initialize pahoMQTT')
+             mqtt = basicMQTT()
         else:
           mqtt = basicMQTT()
         mqtt.connect()

--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -217,11 +217,11 @@ with open(fifo_path, 'r', encoding='UTF-8') as fifo:
           continue
 
         if config['DynRDSmqttEnable'] == "1":
-           try:
-             mqtt = pahoMQTT()
-           except Exception:
-             logging.exception('Unable to initialize pahoMQTT')
-             mqtt = basicMQTT()
+          try:
+            mqtt = pahoMQTT()
+          except Exception:
+            logging.exception('Unable to initialize pahoMQTT')
+            mqtt = basicMQTT()
         else:
           mqtt = basicMQTT()
         mqtt.connect()

--- a/QN8066.py
+++ b/QN8066.py
@@ -130,7 +130,7 @@ class QN8066(Transmitter):
     self.I2C.write(0x24, [0b00000000 | int(max(24,(int(config['DynRDSQN8066ChipPower']) - 70.2) // 0.91))])
     super().status()
 
-  def updateRDSData(self, PSdata, RTdata):
+  def updateRDSData(self, PSdata='', RTdata=''):
     logging.debug('QN8066 updateRDSData')
     super().updateRDSData(PSdata, RTdata)
     self.PS.updateData(PSdata)

--- a/QN8066.py
+++ b/QN8066.py
@@ -11,6 +11,7 @@ from Transmitter import Transmitter
 
 class QN8066(Transmitter):
   def __init__(self):
+    logging.info('Initializing QN8066 transmitter')
     super().__init__()
     self.I2C = basicI2C(0x21)
     self.PS = self.PSBuffer(self, ' ', int(config['DynRDSPSUpdateRate']))
@@ -72,13 +73,13 @@ class QN8066(Transmitter):
         else:
           self.basicPWM = softwarePWM(int(config['DynRDSAdvPIPWMPin']))
           self.basicPWM.startup(10000, int(config['DynRDSQN8066AmpPower']))
-      else:
-        self.basicPWM.startup()
+      #else:
+        #self.basicPWM.startup()
     elif os.getenv('FPPPLATFORM', '') == 'BeagleBone Black':
       self.basicPWM = hardwareBBBPWM(config['DynRDSAdvBBBPWMPin'])
       self.basicPWM.startup(18300, int(config['DynRDSQN8066AmpPower']))
-    else:
-      self.basicPWM.startup()
+    #else:
+      #self.basicPWM.startup()
 
   def update(self):
     # Try without 0x25 0b01111101 - TX Freq Dev of 86.25KHz
@@ -131,6 +132,7 @@ class QN8066(Transmitter):
 
   def updateRDSData(self, PSdata, RTdata):
     logging.debug('QN8066 updateRDSData')
+    super().updateRDSData(PSdata, RTdata)
     self.PS.updateData(PSdata)
     self.RT.updateData(RTdata)
 

--- a/Transmitter.py
+++ b/Transmitter.py
@@ -45,9 +45,10 @@ class Transmitter:
     # Expected to be defined by child class
     pass
 
-  def updateRDSData(self, PSdata, RTdata):
+  def updateRDSData(self, PSdata='', RTdata=''):
     # Expected to be defined by child class
-    pass
+    self.PStext = PSdata
+    self.RTtext = RTdata
 
   def sendNextRDSGroup(self):
     # Expected to be defined by child class

--- a/Transmitter.py
+++ b/Transmitter.py
@@ -22,6 +22,8 @@ class Transmitter:
   def __init__(self):
     # Common class init
     self.active = False
+    self.PStext = ''
+    self.RTtext = ''
 
   def startup(self):
     # Common elements for starting up the transmitter for broadcast

--- a/api.php
+++ b/api.php
@@ -3,7 +3,8 @@
 function getEndpointsDynamic_RDS() {
     $endpoints = array(
        array('method' => 'GET', 'endpoint' => 'FastUpdate', 'callback' => 'DynRDSFastUpdate'),
-       array('method' => 'POST', 'endpoint' => 'PiBootChange/:SettingName', 'callback' => 'DynRDSPiBootChange')
+       array('method' => 'POST', 'endpoint' => 'PiBootChange/:SettingName', 'callback' => 'DynRDSPiBootChange'),
+       array('method' => 'POST', 'endpoint' => 'ScriptStream', 'callback' => 'DynRDSScriptStream')
     );
     return $endpoints;
 }
@@ -55,5 +56,12 @@ function DynRDSPiBootChange() {
         default:
            DynRDSFastUpdate();
     }
+}
+
+function DynRDSScriptStream() {
+    // Get script path & name
+    DisableOutputBuffering();
+    system('~/media/plugins/Dynamic_RDS/scripts/paho_install.sh', $return_val);
+    return "\nDone\n";
 }
 ?>

--- a/api.php
+++ b/api.php
@@ -59,9 +59,20 @@ function DynRDSPiBootChange() {
 }
 
 function DynRDSScriptStream() {
-    // Get script path & name
+    $postData = json_decode(file_get_contents('php://input'), true);
+
     DisableOutputBuffering();
-    system('~/media/plugins/Dynamic_RDS/scripts/paho_install.sh', $return_val);
+
+    switch ($postData['script']) {
+        case 'dependencies':
+           system('~/media/plugins/Dynamic_RDS/scripts/fpp_install.sh', $return_val);
+           break;
+        case 'python3-paho-mqtt':
+           system('~/media/plugins/Dynamic_RDS/scripts/paho_install.sh', $return_val);
+           break;
+        default:
+           return "\nUnknown script\n";
+    }
     return "\nDone\n";
 }
 ?>

--- a/basicI2C.py
+++ b/basicI2C.py
@@ -22,7 +22,7 @@ class basicI2C():
       self.bus = smbus.SMBus(bus)
     except Exception:
       logging.exception("SMBus Init Error")
-    sleep(2)
+    #sleep(2) # TODO: Is this sleep still needed for the bus to init?
 
   def write(self, address, values, isFatal = False):
     # Simple i2c write - Always takes an list, even for 1 byte
@@ -60,3 +60,5 @@ class basicI2C():
       logging.error("failed to read after multiple attempts")
       if isFatal:
         sys.exit(-1)
+      return []
+

--- a/basicI2C.py
+++ b/basicI2C.py
@@ -61,4 +61,3 @@ class basicI2C():
       if isFatal:
         sys.exit(-1)
       return []
-

--- a/basicMQTT.py
+++ b/basicMQTT.py
@@ -5,8 +5,6 @@ import json
 from urllib.request import urlopen
 from urllib.parse import quote
 
-import time
-
 class basicMQTT:
   def __init__(self):
     self.connected = False
@@ -83,3 +81,4 @@ class pahoMQTT(basicMQTT):
         return json.loads(response.read())
     except Exception:
       logging.exception("readAPISetting %s", settingName)
+    return ''

--- a/basicMQTT.py
+++ b/basicMQTT.py
@@ -24,6 +24,7 @@ class basicMQTT:
 class pahoMQTT(basicMQTT):
   # Command line to monitor: mosquitto_sub -v -d -h localhost -t "#"
   def __init__(self):
+    logging.info('Initializing pahoMQTT')
     global paho
     import paho.mqtt.client as paho
 
@@ -49,6 +50,7 @@ class pahoMQTT(basicMQTT):
     super().__init__()
 
   def connect(self):
+    logging.info('Connecting to broker with pahoMQTT')
     self.client.on_connect = self.on_connect
     if self.MQTTSettings['MQTTUsername'] != '':
       self.client.username_pw_set(self.MQTTSettings['MQTTUsername'], self.MQTTSettings['MQTTPassword'])
@@ -60,6 +62,7 @@ class pahoMQTT(basicMQTT):
     self.client.publish(f'{self.topicBase}/{subtopic}', value, qos, retain)
 
   def disconnect(self):
+    logging.info('Disconnecting from broker')
     self.publish('ready', '0')
     self.client.loop_stop()
     self.client.disconnect()
@@ -69,7 +72,8 @@ class pahoMQTT(basicMQTT):
     pass
 
   def on_connect(self, client, userdata, flags, rc):
-    # TODO: Maybe something to log here?
+    logging.info('Connected to broker with pahoMQTT')
+    # TODO: Deal with rc for failures
     super().connect()
 
   def on_publish(self):

--- a/basicMQTT.py
+++ b/basicMQTT.py
@@ -1,4 +1,10 @@
+#!/usr/bin/python3
+
 import logging
+import json
+from urllib.request import urlopen
+from urllib.parse import quote
+
 import time
 
 class basicMQTT:
@@ -8,7 +14,7 @@ class basicMQTT:
   def connect(self):
     self.connected = True
 
-  def publish(self):
+  def publish(self, subtopic, value, qos=1, retain=True):
     pass
 
   def disconnect(self):
@@ -17,48 +23,63 @@ class basicMQTT:
   def status(self):
     pass
 
-class pahoMQTT:
+class pahoMQTT(basicMQTT):
   # Command line to monitor: mosquitto_sub -v -d -h localhost -t "#"
   def __init__(self):
     global paho
     import paho.mqtt.client as paho
-    # Pull MQTTHost, then get all children's values
-    # api/settings/MQTTHost
-    # { "name": "MQTTHost", "description": "Broker Host", "tip": "Hostname or IP of your MQTT broker", "restart": 2, "type": "text", "size": 32, "maxlength": 64, "children": { "*": [ "MQTTPort", "MQTTClientId", "MQTTPrefix", "MQTTUsername", "MQTTPassword", "MQTTCaFile", "MQTTFrequency", "MQTTSubscribe" ] }, "value": "localhost" }
+
+    # Pull in FPP setting needed for MQTT via API
+    self.MQTTSettings = {}
+    self.MQTTSettings['HostName'] = self.readAPISetting('HostName')['value']
+
+    mqttInfo = self.readAPISetting('MQTTHost')
+    self.MQTTSettings['MQTTHost'] = mqttInfo['value']
+
+    for setting in mqttInfo['children']['*']:
+      settingInfo = self.readAPISetting(setting)
+      self.MQTTSettings[setting] = settingInfo['value'] if 'value' in settingInfo else ''
+
+    logging.debug('MQTT Settings %s', self.MQTTSettings)
+
+    self.topicBase = f'falcon/player/{self.MQTTSettings["HostName"]}/plugin/Dynamic_RDS'
+    if self.MQTTSettings["MQTTPrefix"] != '':
+      self.topicBase = f'{self.MQTTSettings["MQTTPrefix"]}/{self.topicBase}'
+
+    self.client = paho.Client()
+    self.client.enable_logger()
     super().__init__()
 
   def connect(self):
-    self.client = paho.Client()
     self.client.on_connect = self.on_connect
-    self.client.connect_async('localhost', 1883)
+    if self.MQTTSettings['MQTTUsername'] != '':
+      self.client.username_pw_set(self.MQTTSettings['MQTTUsername'], self.MQTTSettings['MQTTPassword'])
+    self.client.will_set(f'{self.topicBase}/ready', '-1', 0, True)
+    self.client.connect_async(self.MQTTSettings['MQTTHost'], self.MQTTSettings['MQTTPort'])
     self.client.loop_start()
 
-  def publish(self):
-    self.client.publish('falcon/player/FPP-DevPi/Dynamic_RDS/ready', '1', qos=1)
+  def publish(self, subtopic, value, qos=1, retain=True):
+    self.client.publish(f'{self.topicBase}/{subtopic}', value, qos, retain)
 
   def disconnect(self):
+    self.publish('ready', '0')
     self.client.loop_stop()
+    self.client.disconnect()
+    super().disconnect()
 
   def status(self):
     pass
 
   def on_connect(self, client, userdata, flags, rc):
-    print('On_Connect')
-    self.connected = True
+    # TODO: Maybe something to log here?
+    super().connect()
 
   def on_publish(self):
     pass
 
-print('Init')
-test = pahoMQTT()
-print('Connect')
-test.connect()
-#print('Sleep')
-#time.sleep(5)
-print('Publish')
-test.publish()
-print('Sleep')
-time.sleep(5)
-print('Disconnect')
-test.disconnect()
-print('Done')
+  def readAPISetting(self, settingName):
+    try:
+      with urlopen(f'http://localhost/api/settings/{quote(settingName)}') as response:
+        return json.loads(response.read())
+    except Exception:
+      logging.exception("readAPISetting %s", settingName)

--- a/basicMQTT.py
+++ b/basicMQTT.py
@@ -1,0 +1,64 @@
+import logging
+import time
+
+class basicMQTT:
+  def __init__(self):
+    self.connected = False
+
+  def connect(self):
+    self.connected = True
+
+  def publish(self):
+    pass
+
+  def disconnect(self):
+    self.connected = False
+
+  def status(self):
+    pass
+
+class pahoMQTT:
+  # Command line to monitor: mosquitto_sub -v -d -h localhost -t "#"
+  def __init__(self):
+    global paho
+    import paho.mqtt.client as paho
+    # Pull MQTTHost, then get all children's values
+    # api/settings/MQTTHost
+    # { "name": "MQTTHost", "description": "Broker Host", "tip": "Hostname or IP of your MQTT broker", "restart": 2, "type": "text", "size": 32, "maxlength": 64, "children": { "*": [ "MQTTPort", "MQTTClientId", "MQTTPrefix", "MQTTUsername", "MQTTPassword", "MQTTCaFile", "MQTTFrequency", "MQTTSubscribe" ] }, "value": "localhost" }
+    super().__init__()
+
+  def connect(self):
+    self.client = paho.Client()
+    self.client.on_connect = self.on_connect
+    self.client.connect_async('localhost', 1883)
+    self.client.loop_start()
+
+  def publish(self):
+    self.client.publish('falcon/player/FPP-DevPi/Dynamic_RDS/ready', '1', qos=1)
+
+  def disconnect(self):
+    self.client.loop_stop()
+
+  def status(self):
+    pass
+
+  def on_connect(self, client, userdata, flags, rc):
+    print('On_Connect')
+    self.connected = True
+
+  def on_publish(self):
+    pass
+
+print('Init')
+test = pahoMQTT()
+print('Connect')
+test.connect()
+#print('Sleep')
+#time.sleep(5)
+print('Publish')
+test.publish()
+print('Sleep')
+time.sleep(5)
+print('Disconnect')
+test.disconnect()
+print('Done')

--- a/basicMQTT.py
+++ b/basicMQTT.py
@@ -35,9 +35,17 @@ class pahoMQTT(basicMQTT):
     mqttInfo = self.readAPISetting('MQTTHost')
     self.MQTTSettings['MQTTHost'] = mqttInfo['value']
 
+    if self.MQTTSettings['MQTTHost'] == '':
+      logging.warning('MQTT Broker Host is not set. Check FPP Settings -> MQTT -> Broker Host value')
+      raise Exception('Missing MQTT Host')
+
     for setting in mqttInfo['children']['*']:
       settingInfo = self.readAPISetting(setting)
       self.MQTTSettings[setting] = settingInfo['value'] if 'value' in settingInfo else ''
+
+    if self.MQTTSettings['MQTTPort'] == '':
+      logging.warning('MQTT Port value is missing, using default of 1883')
+      self.MQTTSettings['MQTTPort'] = '1883'
 
     logging.debug('MQTT Settings %s', self.MQTTSettings)
 
@@ -55,7 +63,7 @@ class pahoMQTT(basicMQTT):
     if self.MQTTSettings['MQTTUsername'] != '':
       self.client.username_pw_set(self.MQTTSettings['MQTTUsername'], self.MQTTSettings['MQTTPassword'])
     self.client.will_set(f'{self.topicBase}/ready', '-1', 0, True)
-    self.client.connect_async(self.MQTTSettings['MQTTHost'], self.MQTTSettings['MQTTPort'])
+    self.client.connect_async(self.MQTTSettings['MQTTHost'], int(self.MQTTSettings['MQTTPort']))
     self.client.loop_start()
 
   def publish(self, subtopic, value, qos=1, retain=True):

--- a/basicPWM.py
+++ b/basicPWM.py
@@ -59,7 +59,7 @@ class hardwarePWM(basicPWM):
 
 class softwarePWM(basicPWM):
   def __init__(self, pinToUse=7):
-    logging.info('Initializing software PWM on pin %s', self.pinToUse)
+    logging.info('Initializing software PWM on pin %s', pinToUse)
     global GPIO
     from RPi import GPIO
     self.pinToUse = pinToUse

--- a/basicPWM.py
+++ b/basicPWM.py
@@ -59,12 +59,12 @@ class hardwarePWM(basicPWM):
 
 class softwarePWM(basicPWM):
   def __init__(self, pinToUse=7):
+    logging.info('Initializing software PWM on pin %s', self.pinToUse)
     global GPIO
     from RPi import GPIO
     self.pinToUse = pinToUse
     self.pwm = None
     # TODO: Ponder if import RPi.GPIO as GPIO is a good idea
-    logging.info('Initializing software PWM on pin %s', self.pinToUse)
     GPIO.setmode(GPIO.BOARD)
     GPIO.setup(self.pinToUse, GPIO.OUT)
     GPIO.output(self.pinToUse,0)
@@ -92,6 +92,7 @@ class softwarePWM(basicPWM):
 class hardwareBBBPWM(basicPWM):
   def __init__(self, pwmInfo='P9_16,1,B'):
     (self.pinToUse, self.pwmToUse, self.ABToUse) = pwmInfo.split(',', 2)
+    logging.info('Initializing hardware PWM on pin %s', self.pinToUse)
     if self.pwmToUse == '0':
       self.pwmToUse = '48300200'
     elif self.pwmToUse == '2':

--- a/callbacks.py
+++ b/callbacks.py
@@ -177,6 +177,7 @@ with open(fifo_path, 'w', encoding='UTF-8') as fifo:
       fifo.write('START\n')
     elif playlist_action == 'stop':
       fifo.write('STOP\n')
+      sys.exit()
 
     if j['Section'] == 'MainPlaylist':
       logging.debug('Playlist name %s', j['name'])

--- a/config.py
+++ b/config.py
@@ -26,7 +26,8 @@ config = {
 'DynRDSmpcEnable': '0',
 'DynRDSAdvPISoftwareI2C': '0',
 'DynRDSAdvPIPWMPin': '18,2',
-'DynRDSAdvBBBPWMPin': 'P9_16,1,B'
+'DynRDSAdvBBBPWMPin': 'P9_16,1,B',
+'DynRDSmqttEnable': '0'
 }
 
 def read_config_from_file():

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -2,7 +2,7 @@
 	"repoName": "Dynamic_RDS",
 	"name": "Dynamic RDS",
 	"author": "Nick Anderson (ShadowLight8)",
-	"description": "FM Transmitter plugin to generate customizable RDS messages similar to typical FM stations. Reads multiple fields from the media's metadata. Supports the QN8066 chip.",
+	"description": "Manage an FM Transmitter and generate customizable RDS messages similar to typical FM stations. Reads multiple fields from the media's metadata and playlist. Run on Raspberry Pi and BBB. Supports the QN8066 chip.",
 
 	"homeURL": "https://github.com/ShadowLight8/Dynamic_RDS",
 	"srcURL": "https://github.com/ShadowLight8/Dynamic_RDS.git",

--- a/scripts/fpp_install.sh
+++ b/scripts/fpp_install.sh
@@ -13,5 +13,3 @@ fi
 
 echo -e "\nRestarting FPP..."
 curl -s http://localhost/api/system/fppd/restart
-echo -e "\nDone"
-

--- a/scripts/paho_install.sh
+++ b/scripts/paho_install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo -e "\nInstalling python3-paho-mqtt..."
+sudo apt-get install -y python3-paho-mqtt
+

--- a/settings.json
+++ b/settings.json
@@ -58,6 +58,12 @@
                 "DynRDSmpcEnable"
             ]
         },
+        "DynRDSmqtt": {
+            "description": "MQTT",
+            "settings": [
+                "DynRDSmqttEnable"
+            ]
+        },
         "DynRDSAdv": {
             "description": "Advanced Options",
             "settings": [
@@ -410,6 +416,18 @@
             "uncheckedValue": "0",
             "default": 0,
             "suffix": "<i class='fas fa-fw fa-bolt fa-nbsp ui-level-1'></i>"
+        },
+        "DynRDSmqttEnable": {
+            "name": "DynRDSmqttEnable",
+            "description": "Enable MQTT",
+            "tip": "Enables Dynamic_RDS to publish status to MQTT",
+            "restart": 0,
+            "reboot": 0,
+            "type": "checkbox",
+            "checkedValue": "1",
+            "uncheckedValue": "0",
+            "default": 0,
+            "suffix": ""
         },
         "DynRDSAdvPISoftwareI2C": {
             "name": "DynRDSAdvPISoftwareI2C",


### PR DESCRIPTION
Framework and environment setup
- [x] Config screen and settings work for MQTT support
- [x] Rough paho-mqtt install
- [x] Refine install (also support smbus reinstall)

Functional code
- [x] Publish to ready with startup and shutdown
- [x] Basic publish to status
- [x] Expand to everything published to status

3 MQTT Topics
falcon/player/{FPP Host}/plugin/Dynamic_RDS/ready - 1 indicates running, 0 indicates stopped, -1 indicates error
falcon/player/{FPP Host}/plugin/Dynamic_RDS/status - Live RDS data, what is currently being broadcast, updates when RDS data changes
falcon/player/{FPP Host}/plugin/Dynamic_RDS/config - Plugin configuration data, update when config changes

Includes 2 unrelated bug fixes for not pulling mpc data after a playlist stop
Includes 1 minor logic change for detecting i2c bus and boards