### PR TITLE
Update fpp_install.sh to use python3-rpi-lgpio

### DIFF
--- a/basicI2C.py
+++ b/basicI2C.py
@@ -13,7 +13,8 @@ class basicI2C():
   def __init__(self, address, bus=1):
     self.address = address
     # Bus 1 is Modern RPis, Bus 2 is BBB, Bus 0 is older RPis
-    if os.path.exists('/dev/i2c-2') or os.path.exists('/sys/class/i2c-2'):
+    # uEnv.txt indicates a BBB, so 2 would be ok. On single HDMI port RPi's i2c-2 can show up, but isn't what should be used
+    if os.path.exists('/boot/uEnv.txt') and (os.path.exists('/dev/i2c-2') or os.path.exists('/sys/class/i2c-2')):
       bus = 2
     elif os.path.exists('/dev/i2c-0') or os.path.exists('/sys/class/i2c-0'):
       bus = 0

--- a/scripts/fpp_install.sh
+++ b/scripts/fpp_install.sh
@@ -7,8 +7,8 @@ echo -e "\nInstalling python3-smbus..."
 sudo apt-get install -y python3-smbus
 
 if test -f /boot/config.txt; then
-  echo -e "\nInstalling RPi.GPIO..."
-  sudo apt-get install -y python3-rpi.gpio
+  echo -e "\nInstalling python3-rpi-lgpio..."
+  sudo apt-get install -y python3-rpi-lgpio
 fi
 
 echo -e "\nRestarting FPP..."


### PR DESCRIPTION
Since this is already part of the FPP install, use the python3-rpi-lgpio instead of python3-rpi.gpio

Still need to test that this works for PWM