### PR TITLE
End all RT segments with 0x0d char

### DIFF
--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -74,7 +74,7 @@ def updateRDSData():
 
   # TODO: DynRDSRTSize functionally works, but I think this should source from the RTBuffer class post initialization
   # TODO: Check if transmitter is active?
-  transmitter.updateRDSData(rdsStyleToString(config['DynRDSPSStyle'], 8), rdsStyleToString(config['DynRDSRTStyle'], int(config['DynRDSRTSize'])))
+  transmitter.updateRDSData(rdsStyleToString(config['DynRDSPSStyle'], 8), rdsStyleToString(config['DynRDSRTStyle'], int(config['DynRDSRTSize']) - 1))
 
   if config['DynRDSmqttEnable'] == '1':
     mqttStatus = {}

--- a/Dynamic_RDS_Engine.py
+++ b/Dynamic_RDS_Engine.py
@@ -74,7 +74,7 @@ def updateRDSData():
 
   # TODO: DynRDSRTSize functionally works, but I think this should source from the RTBuffer class post initialization
   # TODO: Check if transmitter is active?
-  transmitter.updateRDSData(rdsStyleToString(config['DynRDSPSStyle'], 8), rdsStyleToString(config['DynRDSRTStyle'], int(config['DynRDSRTSize']) - 1))
+  transmitter.updateRDSData(rdsStyleToString(config['DynRDSPSStyle'], 8), rdsStyleToString(config['DynRDSRTStyle'], int(config['DynRDSRTSize'])))
 
   if config['DynRDSmqttEnable'] == '1':
     mqttStatus = {}

--- a/QN8066.py
+++ b/QN8066.py
@@ -178,7 +178,7 @@ class QN8066(Transmitter):
     # Max fragment size of 64, Groups send 4 characters at a time
     def __init__(self, outer, data, delay=7):
       self.ab = 0
-      super().__init__(data, int(config['DynRDSRTSize']) - 1, 4, delay)
+      super().__init__(data, int(config['DynRDSRTSize']), 4, delay)
       self.outer = outer
 
     def updateData(self, data):

--- a/QN8066.py
+++ b/QN8066.py
@@ -183,9 +183,11 @@ class QN8066(Transmitter):
 
     def updateData(self, data):
       super().updateData(data)
-      # Add 0x0d to end of all fragments to indicate RT is done
+      # Remove all trailing spaces and append chr(0x0d) if length < 64 (max RT fragment size)
       for i in range(len(self.fragments)):
-        self.fragments[i] += chr(0x0d)
+        self.fragments[i] = self.fragments[i].rstrip()
+        if len(self.fragments[i]) < 64:
+          self.fragments[i] += chr(0x0d)
       self.ab = not self.ab
       logging.info('RT %s', self.fragments)
 

--- a/QN8066.py
+++ b/QN8066.py
@@ -178,15 +178,14 @@ class QN8066(Transmitter):
     # Max fragment size of 64, Groups send 4 characters at a time
     def __init__(self, outer, data, delay=7):
       self.ab = 0
-      super().__init__(data, int(config['DynRDSRTSize']), 4, delay)
+      super().__init__(data, int(config['DynRDSRTSize']) - 1, 4, delay)
       self.outer = outer
 
     def updateData(self, data):
       super().updateData(data)
-      # Add 0x0d to end of last fragment to indicate RT is done
-      # TODO: This isn't quite correct - Should put 0x0d where a break is indicated in the rdsStyleText
-      if len(self.fragments[-1]) < self.frag_size:
-        self.fragments[-1] += chr(0x0d)
+      # Add 0x0d to end of all fragments to indicate RT is done
+      for i in range(len(self.fragments)):
+        self.fragments[i] += chr(0x0d)
       self.ab = not self.ab
       logging.info('RT %s', self.fragments)
 


### PR DESCRIPTION
My car was only displaying the last segment of the RS text. After some testing I discovered that the 0x0d was needed to be sent every segment, as noted in the TODO. 
I'm not sure if this is the best fix, feel free to suggest any changes.
